### PR TITLE
Added new function for solving for P_auxillary and energy confinement time

### DIFF
--- a/inputs_arc.py
+++ b/inputs_arc.py
@@ -15,9 +15,8 @@ inputs['plasma_current'] = 7.8 * ureg.MA
 inputs['magnetic_field_on_axis'] = 9.2 *ureg.tesla
 
 inputs['confinement'] = {}
+# Scaling options are 'ITER98y2', 'ITER97', or 'ITER89'
 inputs['confinement']['scaling'] = 'ITER98y2'
-# inputs['confinement']['scaling'] = 'ITER89'
-inputs['confinement']['iteration_threshold'] = 0.01
 inputs['confinement']['H'] = 1.0
 inputs['A'] = 2.5
 
@@ -27,9 +26,9 @@ inputs['P_SOL_method'] = 'total'
 inputs['num_r_points'] = 50
 
 # Electron Temperature Inputs
-inputs['T_min'] = 4 * ureg.keV
+inputs['T_min'] = 1 * ureg.keV
 inputs['T_max'] = 25 * ureg.keV
-inputs['num_T_points'] = 8
+inputs['num_T_points'] = 12
 inputs['profile_alpha'] = {}
 inputs['profile_alpha']['T'] = 1.5
 
@@ -44,14 +43,27 @@ plot_inputs = {}
 plot_inputs['filename'] = 'popcon_test1.png'
 plot_inputs['contours'] = {}
 plot_inputs['contours']['P_fusion'] = {'levels': [1, 10, 100, 1000, 1e4]}
-plot_inputs['contours']['P_auxillary'] = {'levels': [10, 100, 1000, 1e4]}
-plot_inputs['contours']['P_SOL'] = {'levels': [10, 100, 1000, 1e4]}
-plot_inputs['contours']['P_radiation'] = {'levels': [10, 100, 1000, 1e4]}
-plot_inputs['contours']['Q'] = {'levels': [0.1, 1, 10, 100]}
+# plot_inputs['contours']['P_ohmic'] = {'levels': [1, 10, 100, 1000, 1e4]}
+plot_inputs['contours']['P_auxillary'] = {'levels': [1, 10, 20, 30, 40, 50, 100, 1000, 1e4]}
+# plot_inputs['contours']['P_SOL'] = {'levels': [10, 100, 1000, 1e4]}
+# plot_inputs['contours']['P_radiation'] = {'levels': [10, 100, 1000, 1e4]}
+# plot_inputs['contours']['energy_confinement_time'] = {'levels':[0.1, 0.2, 0.4, 0.8, 1.0, 2.0, 10.0]}
+plot_inputs['contours']['Q'] = {'levels': [0.1, 1, 2, 4, 8, 10, 20, 40, 100]}
+plot_inputs['contours']['greenwald_fraction'] = {'levels': [1.0]}
 
 output = popcon.get_all_parameters(inputs)
 
-print(output['P_fusion'])
+print(output['Q'])
+
+fig2, ax2 = plt.subplots(nrows=1, ncols=2, figsize=[12, 9])
+for a in ax2:
+    for i,T in enumerate(output['electron_temperature']):
+        a.plot(output['electron_density'], output['energy_confinement_time'][i,:], label='T={:.1f}'.format(T.to(ureg.keV)))
+    a.legend()
+    a.set_xlabel('Electron Density')
+    a.set_ylabel('Energy Confinement Time')
+ax2[1].set_yscale('log')
+fig2.savefig('energy_confinement_times_ARC.png')
 
 fig, ax = popcon.plot_popcon(output, plot_inputs)
 

--- a/inputs_test.py
+++ b/inputs_test.py
@@ -15,9 +15,8 @@ inputs['plasma_current'] = 10 * ureg.MA
 inputs['magnetic_field_on_axis'] = 10 *ureg.tesla
 
 inputs['confinement'] = {}
-# inputs['confinement']['scaling'] = 'ITER98y2'
+# Scaling options are 'ITER98y2', 'ITER97', or 'ITER89'
 inputs['confinement']['scaling'] = 'ITER89'
-inputs['confinement']['iteration_threshold'] = 0.01
 inputs['confinement']['H'] = 1.0
 inputs['A'] = 2.5
 


### PR DESCRIPTION
This PR adds various functions that calculate P_auxillary using two different methods with various confinement times, and finds the root between the two calculated P_auxillary's using the TOMS 748 method to solve for the confinement time. Two options were added to do this consistent with the two methods for calculating P_SOL:

1. 'total': P_SOL = W_p/tau_E 
2. 'partial': P_SOL = W_p/tau_E - P_radiation

For more info on the theory behind this, refer to: https://cfspopcon.readthedocs.io/en/latest/doc_sources/api.html#cfspopcon.formulas.calc_tau_e_and_P_in_from_scaling
